### PR TITLE
remove emitting and remove async client and allow client to get back …

### DIFF
--- a/ws_client.gemspec
+++ b/ws_client.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
 
   spec.add_dependency "websocket"
-  spec.add_dependency "event_emitter"
 end


### PR DESCRIPTION
…the exceptions that are actually thrown

emitting vs raise the error is causing problems and we just need this for the synchronous side

@film42 @brianstien
